### PR TITLE
feat: neon theme redesign

### DIFF
--- a/app/_blog/page.tsx
+++ b/app/_blog/page.tsx
@@ -16,8 +16,10 @@ export const metadata: Metadata = {
 const Blog = () => {
   return (
     <div className="mt-20 md:mt-32 pb-20">
-      <h1 className="text-2xl text-black">Blog</h1>
-      <h2 className="mt-1 text-gray-500 text-sm">
+      <h1 className="text-3xl text-pink-500 drop-shadow-[0_0_0.5rem_#ff00ff]">
+        Blog
+      </h1>
+      <h2 className="mt-1 text-sm text-fuchsia-200">
         Try to develop the habit of writing articles.
       </h2>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,23 +3,8 @@ import LightRay from '@/components/light-ray'
 import Navbar from '@/components/navbar'
 import { Analytics } from '@vercel/analytics/next'
 import type { Metadata } from 'next'
-import { Geist, Geist_Mono, Instrument_Serif } from 'next/font/google'
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-})
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-})
-
-const instrumentSerif = Instrument_Serif({
-  variable: '--font-instrument-serif',
-  subsets: ['latin'],
-  weight: ['400'],
-})
+// Using system monospace font for a retro look
 
 export const metadata: Metadata = {
   title: 'Yiwei Ho',
@@ -50,11 +35,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable} antialiased`}
-      >
+      <body className="bg-gradient-to-br from-black via-fuchsia-950 to-black text-fuchsia-400 min-h-screen font-mono">
         <LightRay />
-        <div className="container mx-auto font-[family-name:var(--font-geist-mono)] px-6">
+        <div className="container mx-auto px-6">
           <Navbar />
           {children}
         </div>

--- a/app/photo/page.tsx
+++ b/app/photo/page.tsx
@@ -18,8 +18,10 @@ export const metadata: Metadata = {
 const PhotoPage = () => {
   return (
     <div className="mt-20 md:mt-32 pb-20">
-      <h1 className="text-2xl text-black">Photo</h1>
-      <h2 className="mt-1 text-gray-500 text-sm">
+      <h1 className="text-3xl text-pink-500 drop-shadow-[0_0_0.5rem_#ff00ff]">
+        Photo
+      </h1>
+      <h2 className="mt-1 text-sm text-fuchsia-200">
         Some memories I want to cherish.
       </h2>
 
@@ -36,7 +38,7 @@ const PhotoPage = () => {
                 priority={index < 8}
               />
             </AspectRatio>
-            <div className="flex justify-between text-xs text-gray-500 mt-1">
+            <div className="mt-1 flex justify-between text-xs text-fuchsia-200">
               <p>{image.date}</p>
               {image.latitude && image.longitude && (
                 <GoogleMapUrl

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -18,19 +18,21 @@ const Hero = () => {
             className="rounded-full h-16 w-16 md:h-24 md:w-24"
           />
         </ViewTransition>
-        <h1 className="text-2xl md:text-3xl text-black">你好 👋</h1>
+        <h1 className="text-xl md:text-2xl text-emerald-400 drop-shadow-[0_0_0.5rem_#39ff14]">
+          你好 👋
+        </h1>
       </div>
 
-      <h2 className="mt-8 md:mt-16 text-3xl md:text-4xl text-black font-[family-name:var(--font-instrument-serif)]">
+      <h2 className="mt-8 md:mt-16 text-4xl md:text-5xl text-pink-500 drop-shadow-[0_0_0.75rem_#ff00ff]">
         Yiwei Here!
       </h2>
 
-      <div className="mt-6 md:mt-10 max-w-[900px] text-sm md:text-base">
+      <div className="mt-6 md:mt-10 max-w-[900px] text-sm md:text-base text-fuchsia-200">
         <Balancer>
           I am currently a backend developer at Microprogram, where we have
           built a world-class public bike-sharing system in Taiwan. I have a
-          passion for exploring new frontend and backend technologies, and I
-          am deeply inspired by beautiful and innovative designs.
+          passion for exploring new frontend and backend technologies, and I am
+          deeply inspired by beautiful and innovative designs.
         </Balancer>
       </div>
 
@@ -38,7 +40,7 @@ const Hero = () => {
         <Link
           href="https://x.com/1weiho"
           target="_blank"
-          className="flex items-center gap-2 hover:text-black duration-300 group text-sm md:text-base"
+          className="flex items-center gap-2 text-fuchsia-200 transition-colors duration-300 hover:text-pink-500 group text-sm md:text-base"
         >
           <X className="grayscale-0 md:grayscale opacity-100 md:opacity-50 transition-all duration-300 md:group-hover:grayscale-0 md:group-hover:opacity-100" />
           Twitter
@@ -47,7 +49,7 @@ const Hero = () => {
         <Link
           href="https://github.com/1weiho"
           target="_blank"
-          className="flex items-center gap-2 hover:text-black duration-300 group text-sm md:text-base"
+          className="flex items-center gap-2 text-fuchsia-200 transition-colors duration-300 hover:text-pink-500 group text-sm md:text-base"
         >
           <Github className="grayscale-0 md:grayscale opacity-100 md:opacity-50 transition-all duration-300 md:group-hover:grayscale-0 md:group-hover:opacity-100" />
           GitHub

--- a/components/home/project.tsx
+++ b/components/home/project.tsx
@@ -7,8 +7,10 @@ import Link from 'next/link'
 const ProjectItem = ({ title, description, url, category }: Project) => {
   return (
     <Link className="group block" href={url} target="_blank">
-      <div className="flex gap-2 items-center">
-        <h3 className="text-black">{title}</h3>
+      <div className="flex items-center gap-2">
+        <h3 className="text-emerald-400 drop-shadow-[0_0_0.5rem_#39ff14]">
+          {title}
+        </h3>
         {category === 'raycast-extension' ? (
           <Raycast className="grayscale-0 md:grayscale opacity-100 md:opacity-50 transition-all duration-300 md:group-hover:grayscale-0 md:group-hover:opacity-100" />
         ) : category === 'next-js' ? (
@@ -17,7 +19,7 @@ const ProjectItem = ({ title, description, url, category }: Project) => {
           <NPM className="grayscale-0 md:grayscale opacity-100 md:opacity-50 transition-all duration-300 md:group-hover:grayscale-0 md:group-hover:opacity-100" />
         )}
       </div>
-      <p className="mt-2 text-xs md:text-sm">{description}</p>
+      <p className="mt-2 text-xs md:text-sm text-fuchsia-200">{description}</p>
     </Link>
   )
 }

--- a/components/home/projects.tsx
+++ b/components/home/projects.tsx
@@ -37,8 +37,8 @@ const projects: Project[] = [
 
 const Projects = () => {
   return (
-    <div className="md:mt-40 mt-20">
-      <h2 className="mt-16 text-3xl md:text-4xl text-black font-[family-name:var(--font-instrument-serif)]">
+    <div className="mt-20 md:mt-40">
+      <h2 className="mt-16 text-4xl md:text-5xl text-pink-500 drop-shadow-[0_0_0.75rem_#ff00ff]">
         Projects
       </h2>
 

--- a/components/light-ray.tsx
+++ b/components/light-ray.tsx
@@ -1,6 +1,6 @@
 const LightRay = () => {
   return (
-    <div className="absolute top-0 right-0 w-60 h-60 md:w-[500px] md:h-[500px] bg-linear-to-br from-transparent to-amber-300 opacity-30 blur-3xl pointer-events-none"></div>
+    <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,#ff00ff,transparent)] opacity-40 blur-3xl mix-blend-screen animate-pulse"></div>
   )
 }
 

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -24,12 +24,15 @@ const Navbar = () => {
   const currentPathname = `/${usePathname().split('/')[1]}`
 
   return (
-    <nav className="mt-12 flex space-x-6 md:space-x-12">
+    <nav className="mt-12 flex space-x-6 md:space-x-12 text-emerald-400 tracking-widest uppercase">
       {links.map((link) => (
         <Link
           key={link.path}
           href={link.path}
-          className={cn(link.path === currentPathname && 'text-black')}
+          className={cn(
+            'transition-colors hover:text-pink-500',
+            link.path === currentPathname && 'text-pink-500',
+          )}
         >
           {link.title}
         </Link>
@@ -37,7 +40,7 @@ const Navbar = () => {
       <Link
         href="https://links.1wei.dev"
         target="_blank"
-        className="flex items-center gap-1"
+        className="flex items-center gap-1 transition-colors hover:text-pink-500"
       >
         Links
         <ArrowUpRight className="size-4" />

--- a/components/post.tsx
+++ b/components/post.tsx
@@ -8,10 +8,12 @@ const PostItem = ({ slug, title, description, date, tags }: Post) => {
   return (
     <Link
       href={`/blog/${slug}`}
-      className="border block px-6 py-4 rounded-2xl bg-white/20 hover:bg-white/60 duration-150"
+      className="block rounded-2xl border-2 border-pink-500 bg-black/40 px-6 py-4 duration-150 hover:bg-pink-950/40"
     >
-      <h3 className="text-black font-semibold">{title}</h3>
-      <p className="text-sm text-gray-500">{description}</p>
+      <h3 className="font-semibold text-pink-500 drop-shadow-[0_0_0.5rem_#ff00ff]">
+        {title}
+      </h3>
+      <p className="text-sm text-fuchsia-200">{description}</p>
 
       <div className="flex justify-between items-center mt-3">
         <ViewTransition name="avatar">
@@ -25,14 +27,14 @@ const PostItem = ({ slug, title, description, date, tags }: Post) => {
         </ViewTransition>
 
         <div className="flex items-center space-x-4">
-          <p className="text-xs">{date}</p>
+          <p className="text-xs text-fuchsia-200">{date}</p>
           <div className="flex space-x-2">
             {tags?.map((tag, index) => (
               <span
                 key={index}
-                className="text-xs bg-amber-100 px-1.5 py-0.5 rounded-lg flex items-center"
+                className="flex items-center rounded-lg bg-pink-700 px-1.5 py-0.5 text-xs text-fuchsia-200"
               >
-                <Tag className="h-2.5 w-2.5 mr-1" />
+                <Tag className="mr-1 h-2.5 w-2.5" />
                 {tag}
               </span>
             ))}


### PR DESCRIPTION
## Summary
- introduce neon cyberpunk theme with pulsing magenta light and gradient background
- restyle navigation, hero, and content pages with vibrant colors and drop-shadow glow

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e43697248331ab4ca812a3069928