### PR TITLE
style: switch to windows 98 theme

### DIFF
--- a/app/_blog/page.tsx
+++ b/app/_blog/page.tsx
@@ -16,8 +16,8 @@ export const metadata: Metadata = {
 const Blog = () => {
   return (
     <div className="mt-20 md:mt-32 pb-20">
-      <h1 className="text-2xl text-black">Blog</h1>
-      <h2 className="mt-1 text-gray-500 text-sm">
+      <h1 className="text-3xl font-bold text-[#000080]">Blog</h1>
+      <h2 className="mt-1 text-sm text-black">
         Try to develop the habit of writing articles.
       </h2>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,25 +1,7 @@
 import './globals.css'
-import LightRay from '@/components/light-ray'
 import Navbar from '@/components/navbar'
 import { Analytics } from '@vercel/analytics/next'
 import type { Metadata } from 'next'
-import { Geist, Geist_Mono, Instrument_Serif } from 'next/font/google'
-
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-})
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-})
-
-const instrumentSerif = Instrument_Serif({
-  variable: '--font-instrument-serif',
-  subsets: ['latin'],
-  weight: ['400'],
-})
 
 export const metadata: Metadata = {
   title: 'Yiwei Ho',
@@ -50,11 +32,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable} antialiased`}
-      >
-        <LightRay />
-        <div className="container mx-auto font-[family-name:var(--font-geist-mono)] px-6">
+      <body className="bg-[#c0c0c0] text-black min-h-screen font-sans">
+        <div className="container mx-auto px-6">
           <Navbar />
           {children}
         </div>

--- a/app/photo/page.tsx
+++ b/app/photo/page.tsx
@@ -18,8 +18,8 @@ export const metadata: Metadata = {
 const PhotoPage = () => {
   return (
     <div className="mt-20 md:mt-32 pb-20">
-      <h1 className="text-2xl text-black">Photo</h1>
-      <h2 className="mt-1 text-gray-500 text-sm">
+      <h1 className="text-3xl font-bold text-[#000080]">Photo</h1>
+      <h2 className="mt-1 text-sm text-black">
         Some memories I want to cherish.
       </h2>
 
@@ -36,7 +36,7 @@ const PhotoPage = () => {
                 priority={index < 8}
               />
             </AspectRatio>
-            <div className="flex justify-between text-xs text-gray-500 mt-1">
+            <div className="mt-1 flex justify-between text-xs text-black">
               <p>{image.date}</p>
               {image.latitude && image.longitude && (
                 <GoogleMapUrl

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -18,19 +18,21 @@ const Hero = () => {
             className="rounded-full h-16 w-16 md:h-24 md:w-24"
           />
         </ViewTransition>
-        <h1 className="text-2xl md:text-3xl text-black">你好 👋</h1>
+        <h1 className="text-xl md:text-2xl text-[#000080]">
+          你好 👋
+        </h1>
       </div>
 
-      <h2 className="mt-8 md:mt-16 text-3xl md:text-4xl text-black font-[family-name:var(--font-instrument-serif)]">
+      <h2 className="mt-8 md:mt-16 text-4xl md:text-5xl font-bold text-[#000080]">
         Yiwei Here!
       </h2>
 
-      <div className="mt-6 md:mt-10 max-w-[900px] text-sm md:text-base">
+      <div className="mt-6 md:mt-10 max-w-[900px] text-sm md:text-base text-black">
         <Balancer>
           I am currently a backend developer at Microprogram, where we have
           built a world-class public bike-sharing system in Taiwan. I have a
-          passion for exploring new frontend and backend technologies, and I
-          am deeply inspired by beautiful and innovative designs.
+          passion for exploring new frontend and backend technologies, and I am
+          deeply inspired by beautiful and innovative designs.
         </Balancer>
       </div>
 
@@ -38,18 +40,18 @@ const Hero = () => {
         <Link
           href="https://x.com/1weiho"
           target="_blank"
-          className="flex items-center gap-2 hover:text-black duration-300 group text-sm md:text-base"
+          className="flex items-center gap-2 text-blue-700 hover:underline group text-sm md:text-base"
         >
-          <X className="grayscale-0 md:grayscale opacity-100 md:opacity-50 transition-all duration-300 md:group-hover:grayscale-0 md:group-hover:opacity-100" />
+          <X className="opacity-60 group-hover:opacity-100 transition-opacity" />
           Twitter
         </Link>
 
         <Link
           href="https://github.com/1weiho"
           target="_blank"
-          className="flex items-center gap-2 hover:text-black duration-300 group text-sm md:text-base"
+          className="flex items-center gap-2 text-blue-700 hover:underline group text-sm md:text-base"
         >
-          <Github className="grayscale-0 md:grayscale opacity-100 md:opacity-50 transition-all duration-300 md:group-hover:grayscale-0 md:group-hover:opacity-100" />
+          <Github className="opacity-60 group-hover:opacity-100 transition-opacity" />
           GitHub
         </Link>
       </div>

--- a/components/home/project.tsx
+++ b/components/home/project.tsx
@@ -6,18 +6,18 @@ import Link from 'next/link'
 
 const ProjectItem = ({ title, description, url, category }: Project) => {
   return (
-    <Link className="group block" href={url} target="_blank">
-      <div className="flex gap-2 items-center">
-        <h3 className="text-black">{title}</h3>
+    <Link className="group block text-blue-700 hover:underline" href={url} target="_blank">
+      <div className="flex items-center gap-2">
+        <h3 className="font-bold text-[#000080]">{title}</h3>
         {category === 'raycast-extension' ? (
-          <Raycast className="grayscale-0 md:grayscale opacity-100 md:opacity-50 transition-all duration-300 md:group-hover:grayscale-0 md:group-hover:opacity-100" />
+          <Raycast className="opacity-60 group-hover:opacity-100 transition-opacity" />
         ) : category === 'next-js' ? (
-          <Next className="grayscale-0 md:grayscale opacity-100 md:opacity-50 transition-all duration-300 md:group-hover:grayscale-0 md:group-hover:opacity-100" />
+          <Next className="opacity-60 group-hover:opacity-100 transition-opacity" />
         ) : (
-          <NPM className="grayscale-0 md:grayscale opacity-100 md:opacity-50 transition-all duration-300 md:group-hover:grayscale-0 md:group-hover:opacity-100" />
+          <NPM className="opacity-60 group-hover:opacity-100 transition-opacity" />
         )}
       </div>
-      <p className="mt-2 text-xs md:text-sm">{description}</p>
+      <p className="mt-2 text-xs md:text-sm text-black">{description}</p>
     </Link>
   )
 }

--- a/components/home/projects.tsx
+++ b/components/home/projects.tsx
@@ -37,10 +37,8 @@ const projects: Project[] = [
 
 const Projects = () => {
   return (
-    <div className="md:mt-40 mt-20">
-      <h2 className="mt-16 text-3xl md:text-4xl text-black font-[family-name:var(--font-instrument-serif)]">
-        Projects
-      </h2>
+    <div className="mt-20 md:mt-40">
+      <h2 className="mt-16 text-4xl md:text-5xl font-bold text-[#000080]">Projects</h2>
 
       <div className="mt-8 space-y-8 md:space-y-12">
         {projects.map((project, index) => (

--- a/components/light-ray.tsx
+++ b/components/light-ray.tsx
@@ -1,7 +1,0 @@
-const LightRay = () => {
-  return (
-    <div className="absolute top-0 right-0 w-60 h-60 md:w-[500px] md:h-[500px] bg-linear-to-br from-transparent to-amber-300 opacity-30 blur-3xl pointer-events-none"></div>
-  )
-}
-
-export default LightRay

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -24,12 +24,15 @@ const Navbar = () => {
   const currentPathname = `/${usePathname().split('/')[1]}`
 
   return (
-    <nav className="mt-12 flex space-x-6 md:space-x-12">
+    <nav className="mt-12 flex space-x-6 md:space-x-12 text-blue-800">
       {links.map((link) => (
         <Link
           key={link.path}
           href={link.path}
-          className={cn(link.path === currentPathname && 'text-black')}
+          className={cn(
+            'hover:underline',
+            link.path === currentPathname && 'underline',
+          )}
         >
           {link.title}
         </Link>
@@ -37,7 +40,7 @@ const Navbar = () => {
       <Link
         href="https://links.1wei.dev"
         target="_blank"
-        className="flex items-center gap-1"
+        className="flex items-center gap-1 hover:underline"
       >
         Links
         <ArrowUpRight className="size-4" />

--- a/components/post.tsx
+++ b/components/post.tsx
@@ -8,10 +8,10 @@ const PostItem = ({ slug, title, description, date, tags }: Post) => {
   return (
     <Link
       href={`/blog/${slug}`}
-      className="border block px-6 py-4 rounded-2xl bg-white/20 hover:bg-white/60 duration-150"
+      className="block border border-gray-500 bg-[#e0e0e0] px-6 py-4 shadow-[inset_-1px_-1px_0_0_#000,inset_1px_1px_0_0_#fff] hover:bg-[#d4d0c8]"
     >
-      <h3 className="text-black font-semibold">{title}</h3>
-      <p className="text-sm text-gray-500">{description}</p>
+      <h3 className="font-bold text-[#000080]">{title}</h3>
+      <p className="text-sm text-black">{description}</p>
 
       <div className="flex justify-between items-center mt-3">
         <ViewTransition name="avatar">
@@ -25,14 +25,14 @@ const PostItem = ({ slug, title, description, date, tags }: Post) => {
         </ViewTransition>
 
         <div className="flex items-center space-x-4">
-          <p className="text-xs">{date}</p>
+          <p className="text-xs text-black">{date}</p>
           <div className="flex space-x-2">
             {tags?.map((tag, index) => (
               <span
                 key={index}
-                className="text-xs bg-amber-100 px-1.5 py-0.5 rounded-lg flex items-center"
+                className="flex items-center border border-gray-500 bg-[#c0c0c0] px-1.5 py-0.5 text-xs text-black"
               >
-                <Tag className="h-2.5 w-2.5 mr-1" />
+                <Tag className="mr-1 h-2.5 w-2.5" />
                 {tag}
               </span>
             ))}


### PR DESCRIPTION
## Summary
- replace neon aesthetic with gray Windows 98 look and system fonts
- restyle navigation, hero, and content cards with classic blue links and flat panels

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e43697248331ab4ca812a3069928