### PR TITLE
feat(talk): add talk page grouped by year

### DIFF
--- a/app/talk/page.tsx
+++ b/app/talk/page.tsx
@@ -1,0 +1,61 @@
+import { talks } from './talks'
+import Talk from '@/components/talk'
+import { generateOgImageUrl } from '@/lib/utils'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Talk | Yiwei Ho',
+  description: 'Talks given by Yiwei Ho.',
+  openGraph: {
+    title: 'Talk | Yiwei Ho',
+    description: 'Talks given by Yiwei Ho.',
+    images: [{ url: generateOgImageUrl('Talk'), alt: '1wei.dev' }],
+  },
+}
+
+const TalkPage = () => {
+  const talksByYear = talks.reduce(
+    (acc, talk) => {
+      const year = new Date(talk.date).getFullYear().toString()
+      if (!acc[year]) {
+        acc[year] = []
+      }
+      acc[year].push(talk)
+      return acc
+    },
+    {} as Record<string, typeof talks>,
+  )
+
+  const years = Object.keys(talksByYear).sort((a, b) => Number(b) - Number(a))
+
+  return (
+    <div className="mt-20 md:mt-32 pb-20">
+      <h1 className="text-2xl text-black">Talk</h1>
+      <h2 className="mt-1 text-gray-500 text-sm">
+        Sharing what I have learned on stage.
+      </h2>
+
+      <div className="mt-12 space-y-12">
+        {years.map((year) => (
+          <div key={year}>
+            <h3 className="text-4xl text-black/30 font-[family-name:var(--font-instrument-serif)]">
+              {year}
+            </h3>
+            <ul className="divide-y divide-black/10">
+              {talksByYear[year]
+                .sort(
+                  (a, b) =>
+                    new Date(b.date).getTime() - new Date(a.date).getTime(),
+                )
+                .map((talk) => (
+                  <Talk key={talk.title} {...talk} />
+                ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default TalkPage

--- a/app/talk/talks.ts
+++ b/app/talk/talks.ts
@@ -1,0 +1,12 @@
+import { Talk } from '@/lib/type'
+
+const talks = [
+  {
+    title: 'COSCUP 2026',
+    slidesUrl: 'https://slides.1wei.dev/s/coscup-2026',
+    videoUrl: 'https://www.youtube.com/watch?v=BWgFrY91F_I',
+    date: '2026-08-09',
+  },
+] as Talk[]
+
+export { talks }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -15,6 +15,10 @@ const links = [
     title: 'Blog',
   },
   {
+    path: '/talk',
+    title: 'Talk',
+  },
+  {
     path: '/photo',
     title: 'Photo',
   },

--- a/components/talk.tsx
+++ b/components/talk.tsx
@@ -1,0 +1,44 @@
+import { Talk } from '@/lib/type'
+import { parseUrl } from '@/lib/utils'
+import { ArrowUpRight } from 'lucide-react'
+import Link from 'next/link'
+
+const TalkItem = ({ title, slidesUrl, videoUrl, date }: Talk) => {
+  const links = [
+    { label: 'Slides', url: slidesUrl },
+    { label: 'Video', url: videoUrl },
+  ]
+
+  return (
+    <li className="group py-4">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+        <div>
+          <h4 className="text-black font-medium">{title}</h4>
+
+          <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
+            {links.map((link) => (
+              <Link
+                key={link.label}
+                href={link.url}
+                target="_blank"
+                title={parseUrl(link.url)}
+                className="group/link flex items-center gap-0.5 text-xs transition-colors duration-300 hover:text-black"
+              >
+                {link.label}
+                <ArrowUpRight className="size-3 transition-transform duration-300 group-hover/link:-translate-y-0.5 group-hover/link:translate-x-0.5" />
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center shrink-0">
+          <p className="text-xs tabular-nums text-black/40 transition-colors duration-300 group-hover:text-black/60">
+            {date}
+          </p>
+        </div>
+      </div>
+    </li>
+  )
+}
+
+export default TalkItem

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -11,3 +11,10 @@ export interface Post {
   title: string
   date: string
 }
+
+export interface Talk {
+  title: string
+  slidesUrl: string
+  videoUrl: string
+  date: string
+}


### PR DESCRIPTION
Add a /talk page that lists talks grouped by year, mirroring the blog
page layout. Each entry shows the talk title, links to the slides and
video, and the date. Seeded with COSCUP 2026.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CP1YHkajhHKxVoiyTytkcF