### PR TITLE
fix(navbar): tighten mobile sizing so nav no longer hugs screen edges

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -71,7 +71,7 @@ const Navbar = () => {
   return (
     <nav
       ref={navRef}
-      className="relative mt-12 -ml-3 flex items-center gap-1 md:gap-3"
+      className="relative mt-12 -ml-2.5 flex items-center gap-0.5 text-sm md:-ml-3 md:gap-3 md:text-base"
       onMouseLeave={() => setHoveredKey(null)}
     >
       {/* Sliding ghost highlight */}
@@ -101,7 +101,7 @@ const Navbar = () => {
           onFocus={() => setHoveredKey(link.path)}
           onBlur={() => setHoveredKey(null)}
           className={cn(
-            'relative rounded-full px-3 py-1.5 transition-colors duration-300 hover:text-black',
+            'relative rounded-full px-2.5 py-1.5 transition-colors duration-300 hover:text-black md:px-3',
             link.path === currentPathname && 'text-black',
           )}
         >
@@ -117,10 +117,10 @@ const Navbar = () => {
         onMouseEnter={() => setHoveredKey('links')}
         onFocus={() => setHoveredKey('links')}
         onBlur={() => setHoveredKey(null)}
-        className="group relative flex items-center gap-1 rounded-full px-3 py-1.5 transition-colors duration-300 hover:text-black"
+        className="group relative flex items-center gap-1 rounded-full px-2.5 py-1.5 transition-colors duration-300 hover:text-black md:px-3"
       >
         Links
-        <ArrowUpRight className="size-4 transition-transform duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+        <ArrowUpRight className="size-3.5 transition-transform duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 md:size-4" />
       </Link>
     </nav>
   )


### PR DESCRIPTION
## Summary
On mobile, the navbar rendered all five items at full size (16px mono, `px-3` padding, minimal gap), pushing the row flush against both screen edges and making it feel cramped and heavy.

This PR tightens the mobile sizing while leaving desktop (`md:` and up) untouched:
- Drop nav text a step to `text-sm` on mobile
- Reduce item padding `px-3` → `px-2.5` (and align the left offset `-ml-3` → `-ml-2.5`)
- Shrink the Links arrow icon to `size-3.5`

The sliding pill highlight adapts automatically since it measures items via `getBoundingClientRect`.

## Testing
- Verified at 375px viewport: the nav now has clear breathing room on the right instead of touching the edge
- Verified desktop layout is unchanged
- No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)