### PR TITLE
fix(blog): show link favicons in original color

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -69,7 +69,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
               alt={`Favicon of ${domain}`}
               width={16}
               height={16}
-              className="inline-block align-baseline flex-shrink-0 rounded-sm grayscale"
+              className="inline-block align-baseline flex-shrink-0 rounded-sm"
               style={{
                 marginTop: 0,
                 marginBottom: 0,


### PR DESCRIPTION
## What changed

Removed the `grayscale` class from the external-link favicon `<img>` in `mdx-components.tsx`.

## Why

Blog post links render a Google s2 favicon next to the anchor text. The grayscale filter flattened every site icon into the same monochrome blob, making them hard to tell apart. Favicons now render in their original colors.

## Notes for reviewers

- Single-line change; layout, sizing, and alignment (`rounded-sm`, `translateY(2px)`) are untouched.
- Only affects external (`http(s)://`) links inside MDX content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)