### PR TITLE
chore: remove waving emoji animation from hero

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -160,30 +160,6 @@
   }
 }
 
-@keyframes wave {
-  0% {
-    transform: rotate(0deg);
-  }
-  15% {
-    transform: rotate(16deg);
-  }
-  30% {
-    transform: rotate(-8deg);
-  }
-  45% {
-    transform: rotate(14deg);
-  }
-  60% {
-    transform: rotate(-4deg);
-  }
-  75% {
-    transform: rotate(10deg);
-  }
-  100% {
-    transform: rotate(0deg);
-  }
-}
-
 /* Shiki code block baseline styles */
 @layer base {
   pre.shiki {

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -18,12 +18,7 @@ const Hero = () => {
             className="rounded-full h-16 w-16 md:h-24 md:w-24 ring-1 ring-black/10"
           />
         </ViewTransition>
-        <h1 className="text-2xl md:text-3xl text-black">
-          你好{' '}
-          <span className="inline-block origin-[70%_70%] animate-[wave_1.6s_ease-in-out_0.4s_1] motion-reduce:animate-none">
-            👋
-          </span>
-        </h1>
+        <h1 className="text-2xl md:text-3xl text-black">你好 👋</h1>
       </div>
 
       <h2 className="mt-8 md:mt-16 text-3xl md:text-4xl text-black font-[family-name:var(--font-instrument-serif)]">


### PR DESCRIPTION
Drop the wave keyframe animation on the 👋 emoji in the home hero and
delete the now-unused `wave` keyframes from globals.css. The emoji stays,
just static now.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WkKCYk7Atb8x3pvw9bxeGo